### PR TITLE
Add function to clear bound textures.

### DIFF
--- a/core/src/main/kotlin/info/laht/threekt/renderers/GLRenderer.kt
+++ b/core/src/main/kotlin/info/laht/threekt/renderers/GLRenderer.kt
@@ -1661,6 +1661,10 @@ class GLRenderer(
         uniforms["hemisphereLights"]?.needsUpdate = value
     }
 
+    fun resetBoundTextures() {
+        state.resetBoundTextures()
+    }
+
     private inner class OnMaterialDispose : EventLister {
         override fun onEvent(event: Event) {
             val material = event.target as Material

--- a/core/src/main/kotlin/info/laht/threekt/renderers/opengl/GLState.kt
+++ b/core/src/main/kotlin/info/laht/threekt/renderers/opengl/GLState.kt
@@ -514,6 +514,10 @@ internal class GLState {
 
     }
 
+    fun resetBoundTextures() {
+        currentBoundTextures.clear()
+    }
+
     fun reset() {
 
         enabledAttributes.forEachIndexed { i, v ->


### PR DESCRIPTION
This is a fix for: https://github.com/markaren/three.kt/issues/78

So, the problem here is that, when you use textures outside the threekt framework, the `currentBoundTextures` in `GLState` simply becomes invalid. Threekt/Threejs only calls `GL11.glBindTexture` when it needs to, ie when the `currentBoundTextures` is dirty.

This usually becomes a problem when using other frameworks like DriftFX, ImGui etc. who create textures under the hood, resulting in threekt not being in sync anymore.

I have added a function to the `GLRenderer` which clears the `currentBoundTextures`, which will force threekt to call `GL11.bindTexture` again. This function should be used when after you (or a framework) call `GL11.bindTexture`.